### PR TITLE
Help resolve issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -635,9 +635,11 @@ function renderWarmupConfig() {
   if (!providerContainer) return;
 
   const selectedProviders = getUserPreference('selectedProviders') || ['Gmail', 'Outlook'];
+  // Ensure selectedProviders is always an array
+  const selectedProvidersArray = Array.isArray(selectedProviders) ? selectedProviders : ['Gmail', 'Outlook'];
   
   providerContainer.innerHTML = mockData.emailProviders.map(provider => `
-    <div class="provider-option ${selectedProviders.includes(provider.name) ? 'selected' : ''}" data-provider="${provider.name}">
+    <div class="provider-option ${selectedProvidersArray.includes(provider.name) ? 'selected' : ''}" data-provider="${provider.name}">
       <div class="provider-icon">${provider.icon}</div>
       <div class="provider-name">${provider.name}</div>
       <div class="provider-coverage">${provider.coverage}</div>


### PR DESCRIPTION
Ensure `selectedProviders` is always an array to prevent a TypeScript error when user preferences are corrupted or unexpected.

The `selectedProviders` variable, retrieved from user preferences, could sometimes be a non-array value (e.g., string, null, undefined) due to corrupted localStorage data or manual manipulation, leading to a runtime error when `.includes()` was called. This fix adds a type check and falls back to a default array if the stored preference is invalid.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f28d0fe-c5d2-4808-ab32-5d3a0d0a8994">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f28d0fe-c5d2-4808-ab32-5d3a0d0a8994">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

